### PR TITLE
add s3 compatibility for loading meshwork

### DIFF
--- a/skeleton_plot/skel_io.py
+++ b/skeleton_plot/skel_io.py
@@ -7,6 +7,7 @@ except:
     cf_imported = False
 import os
 import io
+from botocore.exceptions import NoCredentialsError
 from . import utils
 
 SWC_COLUMNS = ('id', 'type', 'x', 'y', 'z', 'radius', 'parent',)
@@ -116,9 +117,15 @@ def load_mw(directory, filename):
     
     if "://" not in directory:
         directory = "file://" + directory
-    
-    cf = CloudFiles(directory)
-    binary = cf.get([filename])
+
+    try: 
+        cf = CloudFiles(directory) # using stored credentials
+        binary = cf.get([filename])
+
+    except NoCredentialsError:
+        cf = CloudFiles(directory, use_https=True) # using https (public credentials)
+        binary = cf.get([filename])
+
 
     with io.BytesIO(cf.get(binary[0]['path'])) as f:
         f.seek(0)


### PR DESCRIPTION
Adds a try-except to implement cloudFiles use_https=True if loading a meshwork cannot find default credentials